### PR TITLE
Return on error and close the response body

### DIFF
--- a/rate.go
+++ b/rate.go
@@ -63,11 +63,14 @@ func request(i int) {
 	resp, err := client.Do(req)
 	if err != nil {
 		println(err.Error())
+		return
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		println(err.Error())
 	}
+	resp.Body.Close()
+
 	fmt.Println(i, resp.StatusCode, len(body))
 	if code != resp.StatusCode && !cont {
 		os.Exit(5)


### PR DESCRIPTION
Your code was trying to read from the response body even if there was error, so I've added return after printing the error. It should fix error #1. It's also good practice to close response body after you're done with it. Hope it helps!